### PR TITLE
fix(commitizen): updated Commitizen Release Note Generator Config

### DIFF
--- a/configs/commit.hbs
+++ b/configs/commit.hbs
@@ -1,0 +1,71 @@
+✅{{#if scope}}
+  **{{scope}}:**
+{{~/if}}
+{{#if subject}}
+  {{~subject}}
+{{~else}}
+  {{~header}}
+{{~/if}}
+
+{{~! commit link }}
+{{#if @root.linkReferences~}}
+  ([{{shortHash}}](
+  {{~#if @root.repository}}
+    {{~#if @root.host}}
+      {{~@root.host}}/
+    {{~/if}}
+    {{~#if @root.owner}}
+      {{~@root.owner}}/
+    {{~/if}}
+    {{~@root.repository}}
+  {{~else}}
+    {{~@root.repoUrl}}
+  {{~/if}}/
+  {{~@root.commit}}/{{hash}}))
+{{~else}}
+  {{~shortHash}}
+{{~/if}}
+
+{{~! commit references }}
+{{~#if references~}}
+  , closes
+  {{~#each references}}
+    {{#if @root.linkReferences~}}
+      [
+      {{~#if this.owner}}
+        {{~this.owner}}/
+      {{~/if}}
+      {{~this.repository}}#{{this.issue}}](
+      {{~#if @root.repository}}
+        {{~#if @root.host}}
+          {{~@root.host}}/
+        {{~/if}}
+        {{~#if this.repository}}
+          {{~#if this.owner}}
+            {{~this.owner}}/
+          {{~/if}}
+          {{~this.repository}}
+        {{~else}}
+          {{~#if @root.owner}}
+            {{~@root.owner}}/
+          {{~/if}}
+          {{~@root.repository}}
+        {{~/if}}
+      {{~else}}
+        {{~@root.repoUrl}}
+      {{~/if}}/
+      {{~@root.issue}}/{{this.issue}})
+    {{~else}}
+      {{~#if this.owner}}
+        {{~this.owner}}/
+      {{~/if}}
+      {{~this.repository}}#{{this.issue}}
+    {{~/if}}{{/each}}
+{{~/if}}
+
+{{~#if body}}
+  {{#raw}}{{/raw}}
+  {{body}}
+{{~/if}}
+
+{{#raw}}{{/raw}}


### PR DESCRIPTION
* Added code in commit.hbs to complete the setup for @semantic-release/release-notes-generator 
* Now semantic-release should include details of a commit msg